### PR TITLE
Benchmark fixes

### DIFF
--- a/android-performance/build.gradle
+++ b/android-performance/build.gradle
@@ -62,15 +62,23 @@ task generateReport {
         // take first file from reports directory
         def xmlFile = fileTree(dir: reportsDir, include: '*.xml').first()
         def suite = new XmlSlurper().parse(xmlFile)
-        def testData = { testName ->
-            def m = testName =~ /performance\[(\w+)\/((\w+)\/)?(\w+)(:(\d+))?]/
-            if (m) [name: m[0][1], subname: m[0][3], impl: m[0][4], runs: (m[0][6] ?: 1) as int] else [:]
+        def testData = { String caseName ->
+            def m = caseName =~ /performance\[(.+)\]/
+            if (m) {
+                def (name, impl, runs) = m[0][1].split("[/:]") + [null]
+                runs = runs ? runs.replaceAll("[^0-9]", "") as int : 1
+                [name: name, impl: impl, runs: runs]
+            } else {
+                System.err.println "Can't parse data from test name '$caseName'"
+                [:]
+            }
+
         }
         def results = suite.testcase
-                .collect { testData(it.@name) + [time: it.@time.toString() as float] }
+                .collect { testData(it.@name.toString()) + [time: it.@time.toString() as float] }
                 .findAll { it.name != null }
                 .collect {
-                    [name: it.name + (it.subname ? " ($it.subname)" : ""), impl: it.impl, time: it.time * 1000 / it.runs]
+                    [name: it.name, impl: it.impl, time: it.time * 1000 / it.runs]
                 }
 
         def allImpl = results*.impl.unique()

--- a/android-performance/build.gradle
+++ b/android-performance/build.gradle
@@ -44,7 +44,7 @@ android {
 }
 
 ext.reportsDir = file("$buildDir/outputs/androidTest-results/connected")
-ext.outputReportFile = file("$buildDir/reports/android-performance.tsv")
+ext.outputReportFile = file("$buildDir/reports/android-performance-0.tsv")
 if (ext.outputReportFile.exists()) {
     for (int i = 1; i < 1000; i++) {
         def f = file("$buildDir/reports/android-performance-${i}.tsv")
@@ -70,7 +70,7 @@ task generateReport {
                 .collect { testData(it.@name) + [time: it.@time.toString() as float] }
                 .findAll { it.name != null }
                 .collect {
-                    [name: it.name + (it.subname ? " ($it.subname)" : ""), impl: it.impl, time: it.time / it.runs]
+                    [name: it.name + (it.subname ? " ($it.subname)" : ""), impl: it.impl, time: it.time * 1000 / it.runs]
                 }
 
         def allImpl = results*.impl.unique()
@@ -78,7 +78,7 @@ task generateReport {
         def tsv = header + results.groupBy { it.name }
             .collect { name, value ->
                 def times = value.collectEntries { [(it.impl): it.time] }
-                [name] + allImpl.collect { times[it].trunc(3) }
+                [name] + allImpl.collect { times[it].trunc(3).toString().replaceAll('[.]', ',') }
             }
             .collect { it.join('\t') }
             .join('\n')

--- a/android-performance/build.gradle
+++ b/android-performance/build.gradle
@@ -44,16 +44,7 @@ android {
 }
 
 ext.reportsDir = file("$buildDir/outputs/androidTest-results/connected")
-ext.outputReportFile = file("$buildDir/reports/android-performance-0.tsv")
-if (ext.outputReportFile.exists()) {
-    for (int i = 1; i < 1000; i++) {
-        def f = file("$buildDir/reports/android-performance-${i}.tsv")
-        if (!f.exists()) {
-            ext.outputReportFile = f
-            break;
-        }
-    }
-}
+ext.outputReportFile = reportFile(file("$buildDir/reports"), "android-performance-%index%.tsv")
 
 task generateReport {
     inputs.dir reportsDir

--- a/android-performance/src/androidTest/java/org/greenrobot/essentials/androidperf/PipelineStreamAndroidBenchmark.java
+++ b/android-performance/src/androidTest/java/org/greenrobot/essentials/androidperf/PipelineStreamAndroidBenchmark.java
@@ -7,11 +7,13 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class PipelineStreamAndroidBenchmark extends AbstractAndroidBenchmark {
+    public static final int STREAM_LENGTH = 100 * 1024; // 100KB
+
     @Parameterized.Parameters(name = "{0}:{1}")
     public static Collection parameters() {
         return Arrays.asList(new Object[][]{
-            {new PipelineStreamBenchmark.StdImpl(), 1},
-            {new PipelineStreamBenchmark.LibImpl(), 100},
+            {new PipelineStreamBenchmark.StdImpl(STREAM_LENGTH), 10},
+            {new PipelineStreamBenchmark.LibImpl(STREAM_LENGTH), 1000},
         });
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,3 +10,13 @@ task wrapper(type: Wrapper) {
     gradleVersion = '2.12'
 }
 
+def reportFile(File parentDir, String templateName) {
+    def file
+    for (int i = 0; i < 1000; i++) {
+        file = new File(parentDir, templateName.replaceAll('%index%', i as String))
+        if (!file.exists()) {
+            return file;
+        }
+    }
+    return file
+}

--- a/java-essentials-performance/benchmarks.gradle
+++ b/java-essentials-performance/benchmarks.gradle
@@ -57,10 +57,9 @@ task allBenchmarks {
         }.flatten()
 
         def testData = { lineResult ->
-            def m = lineResult =~ /(\w+)\/((\w+)\/)?(\w+):([0-9.,]+)/
+            def m = lineResult =~ /([^\/]+)\/(\w+):([0-9.,]+)/
             if (m) {
-                def name = m[0][1] + (m[0][3] ? " (${m[0][3]})" : "")
-                [name: name, impl: m[0][4], time: m[0][5] as float]
+                [name: m[0][1], impl: m[0][2], time: m[0][3] as float]
             } else [:]
         }
         def results = lineResults.collect(testData).findAll{it.name != null}

--- a/java-essentials-performance/benchmarks.gradle
+++ b/java-essentials-performance/benchmarks.gradle
@@ -35,7 +35,7 @@ ext.benchmarks = [
     [tests: ['StringHexBenchmark$StdImpl', 'StringHexBenchmark$LibImpl'], runs: 1000, warmUp: 10]
 ]
 
-ext.reportFile = file("$buildDir/reports/performance.tsv")
+ext.reportFile = reportFile(file("$buildDir/reports"), "performance-%index%.tsv")
 
 // using cpu time for measurements instead of wall time can be specified with -DcpuTime
 ext.useWallTime = !project.hasProperty('cpuTime')
@@ -44,7 +44,6 @@ ext.useWallTime = !project.hasProperty('cpuTime')
 task allBenchmarks {
     dependsOn compileJava
     inputs.sourceDir sourceSets.main.java.srcDirs.first()
-    outputs.file reportFile
 
     doFirst {
         reportFile.parentFile.mkdirs()

--- a/java-essentials-performance/benchmarks.gradle
+++ b/java-essentials-performance/benchmarks.gradle
@@ -23,18 +23,6 @@ def benchmark(className, runs, warmUpSeconds, useWallTime = false) {
     return line
 }
 
-/** Runs each of 2 benchmarks in separate JVM */
-def vs(classNameA, classNameB, times, warmUpSeconds) {
-    benchmark classNameA, times, warmUpSeconds
-    benchmark classNameB, times, warmUpSeconds
-}
-
-
-def vsWall(classNameA, classNameB, times, warmUpSeconds) {
-    benchmark classNameA, times, warmUpSeconds, true
-    benchmark classNameB, times, warmUpSeconds, true
-}
-
 ext.benchmarks = [
     [tests: ['LongHashSetBenchmark$StdImpl', 'LongHashSetBenchmark$LibImpl'], runs: 1000, warmUp: 5],
     [tests: ['LongHashSetBenchmark$PreallocStdImpl', 'LongHashSetBenchmark$PreallocLibImpl'], runs: 1000, warmUp: 5],
@@ -57,6 +45,10 @@ task allBenchmarks {
     dependsOn compileJava
     inputs.sourceDir sourceSets.main.java.srcDirs.first()
     outputs.file reportFile
+
+    doFirst {
+        reportFile.parentFile.mkdirs()
+    }
 
     doLast {
         println "Using ${useWallTime ? 'wall' : 'cpu'} time for benchmarks"

--- a/java-essentials-performance/src/main/java/org/greenrobot/essentials/javaperf/LongHashMapBenchmark.java
+++ b/java-essentials-performance/src/main/java/org/greenrobot/essentials/javaperf/LongHashMapBenchmark.java
@@ -69,7 +69,7 @@ public class LongHashMapBenchmark {
 
         @Override
         public String toString() {
-            return "LongHashMap/Dynamic/Lib";
+            return "LongHashMap (Dynamic)/Lib";
         }
     }
 
@@ -112,7 +112,7 @@ public class LongHashMapBenchmark {
 
         @Override
         public String toString() {
-            return "LongHashMap/Dynamic/Std";
+            return "LongHashMap (Dynamic)/Std";
         }
     }
 
@@ -123,7 +123,7 @@ public class LongHashMapBenchmark {
 
         @Override
         public String toString() {
-            return "LongHashMap/Prealloc/Lib";
+            return "LongHashMap (Prealloc)/Lib";
         }
     }
 
@@ -134,7 +134,7 @@ public class LongHashMapBenchmark {
 
         @Override
         public String toString() {
-            return "LongHashMap/Prealloc/Std";
+            return "LongHashMap (Prealloc)/Std";
         }
     }
 }

--- a/java-essentials-performance/src/main/java/org/greenrobot/essentials/javaperf/LongHashSetBenchmark.java
+++ b/java-essentials-performance/src/main/java/org/greenrobot/essentials/javaperf/LongHashSetBenchmark.java
@@ -68,7 +68,7 @@ public class LongHashSetBenchmark {
 
         @Override
         public String toString() {
-            return "LongHashSet/Dynamic/Lib";
+            return "LongHashSet (Dynamic)/Lib";
         }
     }
 
@@ -110,7 +110,7 @@ public class LongHashSetBenchmark {
 
         @Override
         public String toString() {
-            return "LongHashSet/Dynamic/Std";
+            return "LongHashSet (Dynamic)/Std";
         }
     }
 
@@ -121,7 +121,7 @@ public class LongHashSetBenchmark {
 
         @Override
         public String toString() {
-            return "LongHashSet/Prealloc/Lib";
+            return "LongHashSet (Prealloc)/Lib";
         }
     }
 
@@ -132,7 +132,7 @@ public class LongHashSetBenchmark {
 
         @Override
         public String toString() {
-            return "LongHashSet/Prealloc/Std";
+            return "LongHashSet (Prealloc)/Std";
         }
     }
 }

--- a/java-essentials-performance/src/main/java/org/greenrobot/essentials/javaperf/StringSplitBenchmark.java
+++ b/java-essentials-performance/src/main/java/org/greenrobot/essentials/javaperf/StringSplitBenchmark.java
@@ -3,11 +3,12 @@ package org.greenrobot.essentials.javaperf;
 import org.greenrobot.essentials.StringUtils;
 
 public class StringSplitBenchmark {
-    static int TINY_REPEAT_COUNT = 2000;
-    static int SHORT_REPEAT_COUNT = 1000;
+    static final int TINY_REPEAT_COUNT = 2000;
+    static final int SHORT_REPEAT_COUNT = 1000;
+    static final int LONG_STRING_WORDS_COUNT = 10000;
     static String TINY_STRING = "John Doe";
     static String SHORT_STRING = "The quick brown fox jumps over the lazy dog";
-    static String LONG_STRING = generateLongString(10000);
+    static String LONG_STRING = generateLongString(LONG_STRING_WORDS_COUNT);
 
     public static void main(String[] args) {
         BenchmarkRunner.run(new ShortLibImpl(), 100, 3);
@@ -33,6 +34,9 @@ public class StringSplitBenchmark {
                 final String[] strings = StringUtils.split(SHORT_STRING, ' ');
                 count += strings.length;
             }
+            if (count != 9 * SHORT_REPEAT_COUNT) {
+                throw new RuntimeException("Check test condition");
+            }
         }
 
         @Override
@@ -48,6 +52,9 @@ public class StringSplitBenchmark {
             for (int i = 0; i < SHORT_REPEAT_COUNT; i++) {
                 final String[] strings = SHORT_STRING.split(" ");
                 count += strings.length;
+            }
+            if (count != 9 * SHORT_REPEAT_COUNT) {
+                throw new RuntimeException("Check test condition");
             }
         }
 
@@ -65,6 +72,9 @@ public class StringSplitBenchmark {
                 final String[] strings = StringUtils.split(TINY_STRING, ' ');
                 count += strings.length;
             }
+            if (count != 2 * TINY_REPEAT_COUNT) {
+                throw new RuntimeException("Check test condition");
+            }
         }
 
         @Override
@@ -81,6 +91,9 @@ public class StringSplitBenchmark {
                 final String[] strings = TINY_STRING.split(" ");
                 count += strings.length;
             }
+            if (count != 2 * TINY_REPEAT_COUNT) {
+                throw new RuntimeException("Check test condition");
+            }
         }
 
         @Override
@@ -93,6 +106,9 @@ public class StringSplitBenchmark {
         @Override
         public void run() {
             final String[] strings = StringUtils.split(LONG_STRING, ' ');
+            if (strings.length != LONG_STRING_WORDS_COUNT + 1) { // "+ 1" for the last closing space
+                throw new RuntimeException("Check test condition");
+            }
         }
 
         @Override
@@ -105,6 +121,9 @@ public class StringSplitBenchmark {
         @Override
         public void run() {
             final String[] strings = LONG_STRING.split(" ");
+            if (strings.length != LONG_STRING_WORDS_COUNT) {
+                throw new RuntimeException("Check test condition");
+            }
         }
 
         @Override

--- a/java-essentials-performance/src/main/java/org/greenrobot/essentials/javaperf/StringSplitBenchmark.java
+++ b/java-essentials-performance/src/main/java/org/greenrobot/essentials/javaperf/StringSplitBenchmark.java
@@ -5,13 +5,23 @@ import org.greenrobot.essentials.StringUtils;
 public class StringSplitBenchmark {
     static final int TINY_REPEAT_COUNT = 2000;
     static final int SHORT_REPEAT_COUNT = 1000;
-    static final int LONG_STRING_WORDS_COUNT = 10000;
+    static final int LONG_WORDS_COUNT = 10000;
     static String TINY_STRING = "John Doe";
     static String SHORT_STRING = "The quick brown fox jumps over the lazy dog";
-    static String LONG_STRING = generateLongString(LONG_STRING_WORDS_COUNT);
+    static String LONG_STRING = generateLongString(LONG_WORDS_COUNT);
+    static final int TINY_WORDS_COUNT = StringUtils.split(TINY_STRING, ' ').length;
+    static final int SHORT_WORDS_COUNT = StringUtils.split(SHORT_STRING, ' ').length;
 
     public static void main(String[] args) {
         BenchmarkRunner.run(new ShortLibImpl(), 100, 3);
+    }
+
+    static String name(int wordsCount, int times, String impl) {
+        if (times > 1) {
+            return "StringSplit (" + wordsCount + " words, " + times + " times)/" + impl;
+        } else {
+            return "StringSplit (" + wordsCount + " words)/" + impl;
+        }
     }
 
     private StringSplitBenchmark() {
@@ -41,7 +51,7 @@ public class StringSplitBenchmark {
 
         @Override
         public String toString() {
-            return "StringSplit/Short/Lib";
+            return name(SHORT_WORDS_COUNT, SHORT_REPEAT_COUNT, "Lib");
         }
     }
 
@@ -60,7 +70,7 @@ public class StringSplitBenchmark {
 
         @Override
         public String toString() {
-            return "StringSplit/Short/Std";
+            return name(SHORT_WORDS_COUNT, SHORT_REPEAT_COUNT, "Std");
         }
     }
 
@@ -79,7 +89,7 @@ public class StringSplitBenchmark {
 
         @Override
         public String toString() {
-            return "StringSplit/Tiny/Lib";
+            return name(TINY_WORDS_COUNT, TINY_REPEAT_COUNT, "Lib");
         }
     }
 
@@ -98,7 +108,7 @@ public class StringSplitBenchmark {
 
         @Override
         public String toString() {
-            return "StringSplit/Tiny/Std";
+            return name(TINY_WORDS_COUNT, TINY_REPEAT_COUNT, "Std");
         }
     }
 
@@ -106,14 +116,14 @@ public class StringSplitBenchmark {
         @Override
         public void run() {
             final String[] strings = StringUtils.split(LONG_STRING, ' ');
-            if (strings.length != LONG_STRING_WORDS_COUNT + 1) { // "+ 1" for the last closing space
+            if (strings.length != LONG_WORDS_COUNT + 1) { // "+ 1" for the last closing space
                 throw new RuntimeException("Check test condition");
             }
         }
 
         @Override
         public String toString() {
-            return "StringSplit/Long/Lib";
+            return name(LONG_WORDS_COUNT, 1, "Lib");
         }
     }
 
@@ -121,14 +131,14 @@ public class StringSplitBenchmark {
         @Override
         public void run() {
             final String[] strings = LONG_STRING.split(" ");
-            if (strings.length != LONG_STRING_WORDS_COUNT) {
+            if (strings.length != LONG_WORDS_COUNT) {
                 throw new RuntimeException("Check test condition");
             }
         }
 
         @Override
         public String toString() {
-            return "StringSplit/Long/Std";
+            return name(LONG_WORDS_COUNT, 1, "Std");
         }
     }
 }


### PR DESCRIPTION
- add more information into the name of the test, like `PipelineStream (100KB)`, `StringSplit (1000 words, 100 times)`
- use milliseconds as time units both for android and jvm benchmarks

... and more, see commit messages